### PR TITLE
Don't sort params twice

### DIFF
--- a/thumbnail.go
+++ b/thumbnail.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
-
-	"github.com/facette/natsort"
 )
 
 // Options is the options passed to GenerateThumbnailURL() function.
@@ -31,22 +29,12 @@ func NewOptions() *Options {
 
 // BuildParams builds params for SignParams.
 func BuildParams(params map[string]string) url.Values {
-	var sortedKeys []string
-
-	for k := range params {
-		sortedKeys = append(sortedKeys, k)
-	}
-
-	natsort.Sort(sortedKeys)
-
 	values := url.Values{}
-	for _, k := range sortedKeys {
-		v := params[k]
+	for k, v := range params {
 		if v != "" {
 			values.Add(k, v)
 		}
 	}
-
 	return values
 }
 

--- a/thumbnail_test.go
+++ b/thumbnail_test.go
@@ -92,3 +92,13 @@ func TestGetThumbnailURL(t *testing.T) {
 		sig)
 	is.Equal(expectedURL, url)
 }
+func BenchmarkBuildParams(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		BuildParams(map[string]string{
+			"w":    "20",
+			"h":    "20",
+			"op":   "thumbnail",
+			"path": "/my/path/to/image.jpg",
+		})
+	}
+}


### PR DESCRIPTION
1. Sorting keys from a map[string]string to insert them in a
map[string][]string makes little sense.
2. https://golang.org/pkg/net/url/#Values.Encode does sort the keys
3. On the server side we no longer sort the keys, see https://github.com/thoas/picfit/commit/3530bf29c1ef1dbef96d5179055f8c776ceffe1a
4. Here is the speedup:
```bash
    # before
    $ go test -bench=.
    goos: linux
    goarch: amd64
    pkg: github.com/ulule/picfit-go
    BenchmarkBuildParams-4   	  200000	      5735 ns/op
    PASS
    ok  	github.com/ulule/picfit-go	1.238s
    # after
    $ go test -bench=.
    goos: linux
    goarch: amd64
    pkg: github.com/ulule/picfit-go
    BenchmarkBuildParams-4   	 3000000	       548 ns/op
    PASS
    ok  	github.com/ulule/picfit-go	2.212s
```